### PR TITLE
Addition of 'notContains' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ cy.verifyDownload('picture.png');
 cy.verifyDownload('.png', { contains: true });
 cy.verifyDownload('pic', { contains: true });
 
+// verify download not exist by file extension or partial filename
+// if the 'contains' parameter is informed, the 'notContains' parameter is ignored
+cy.verifyDownload('.png', { notCcontains: true });
+cy.verifyDownload('pic', { notContains: true });
+
 // or increase timeout
 cy.verifyDownload('archive.zip', { timeout: 25000 });
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,15 +5,16 @@ declare namespace Cypress {
     /**
      * Custom command to verify that file has been downloaded
      * @param fileName - string
-     * @param options - { timeout: number, interval: number, contains: boolean }
+     * @param options - { timeout: number, interval: number, contains: boolean, notContains: boolean }
      * @example
      *  cy.verifyDownload('filename.zip')
      *  cy.verifyDownload('filename.zip', { timeout: 20000, interval: 500 });
      *  cy.verifyDownload('.zip', { contains: true });
+     *  cy.verifyDownload('.zip', { notContains: true });
      */
     verifyDownload(
       fileName: string,
-      options?: { timeout?: number; interval?: number; contains?: boolean }
+      options?: { timeout?: number; interval?: number; contains?: boolean, notContains?: boolean }
     ): Chainable<boolean>;
   }
 }


### PR DESCRIPTION
Added parameter '**notContains**' to check if the file has not been downloaded from the cypress download repository. Checks if any files in downloads have part of the name passed as a parameter.

If '**contains**' is also given, '**notContains**' will be ignored.

The revised code just returns '**True**' or '**False**' unless an error occurs, in which case it returns a '**throw**'.

Added some more validations of variables at the beginning for code execution.