### PR TITLE
Update the contains option to not use a random file name if the file not exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,13 +40,16 @@ const addCustomCommand = () => {
 
       if (contains) {
         result = cy.task('findFiles', { path: downloadsFolder, fileName }).then((files) => {
+          let isFileExist = false;
           if (files !== null && files[0]) {
             if (files.length > 1)
               cy.log(
                 `**WARNING!** More than one file found for the **'${fileName}'** pattern: [${files}] - the first one **[${files[0]}]** will be used`
               );
-            return cy.task('isFileExist', join(downloadsFolder, files[0]));
+
+            isFileExist = cy.task('isFileExist', join(downloadsFolder, files[0]));
           }
+          return isFileExist;
         });
       } else {
         result = cy.task('isFileExist', downloadFileName);


### PR DESCRIPTION
To fix the problem in : https://github.com/elaichenkov/cy-verify-downloads/issues/92

Remove the usage of randomBytes and check if the findFiles return a file or not before check if the file exist.